### PR TITLE
Enable create_gitops_prs rule again

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ For the full list of `create_gitops_prs` command line options, run:
 bazel run @rules_gitops//gitops/prer:create_gitops_prs
 ```
 
+Alternatively, you can use the `create_gitops_prs` rule that references `gitops` targets. You can run the target to template yaml & image push in parallel.
+
 <a name="gitops-and-deployment-supported-git-servers"></a>
 ### Supported Git Servers
 

--- a/gitops/create_gitops_prs.tpl.sh
+++ b/gitops/create_gitops_prs.tpl.sh
@@ -2,6 +2,7 @@
 set -x
 set -e
 
-GIT_COMMIT=$(git rev-parse HEAD)
+CURR_GIT_COMMIT=$(git rev-parse HEAD)
+GIT_COMMIT=${BUILDKITE_COMMIT:-$CURR_GIT_COMMIT}
 
-%{prer} --git_commit=$GIT_COMMIT %{params} "${@}"
+%{prer} --git_commit $GIT_COMMIT %{params}

--- a/gitops/gitops.bzl
+++ b/gitops/gitops.bzl
@@ -40,6 +40,15 @@ def __create_gitops_prs_impl(ctx):
         params += "--github_repo_owner {} ".format(ctx.attr.github_repo_owner)
     if ctx.attr.github_repo:
         params += "--github_repo {} ".format(ctx.attr.github_repo)
+    # Etsy Custom params
+    if ctx.attr.github_app_id:
+        params += "--github_app_id {} ".format(ctx.attr.github_app_id)
+    if ctx.attr.github_installation_id:
+        params += "--github_installation_id {} ".format(ctx.attr.github_installation_id)
+    if ctx.attr.github_app_repo_owner:
+        params += "--github_app_repo_owner {} ".format(ctx.attr.github_app_repo_owner)
+    if ctx.attr.private_key:
+        params += "--private_key {} ".format(ctx.attr.private_key)
 
     ctx.actions.expand_template(
         template = ctx.file._tpl,
@@ -126,6 +135,19 @@ create_gitops_prs = rule(
             allow_single_file = True,
             cfg = "exec",
             executable = True,
+        ),
+        # Etsy Custom params
+        "github_app_id": attr.string(
+            doc = "GitHub App Id"
+        ),
+        "github_installation_id": attr.string(
+            doc = "GitHub App Installation Id"
+        ),
+        "github_app_repo_owner": attr.string(
+            doc = "the owner user/organization to use for github api requests"
+        ),
+        "private_key": attr.string(
+            doc = "Private Key"
         ),
     },
     executable = True,

--- a/gitops/prer/create_gitops_prs.go
+++ b/gitops/prer/create_gitops_prs.go
@@ -161,8 +161,8 @@ func processResolvedImages(cfg *Config) {
 	for i := 0; i < cfg.PushParallelism; i++ {
 		go func() {
 			defer wg.Done()
-			for target := range resolvedPushChan {
-				processTarget(target, cfg.BazelCmd)
+			for cmd := range resolvedPushChan {
+				exec.Mustex("", cmd)
 			}
 		}()
 	}

--- a/gitops/prer/create_gitops_prs.go
+++ b/gitops/prer/create_gitops_prs.go
@@ -58,6 +58,10 @@ type Config struct {
 	PRBody                 string
 	DeploymentBranchSuffix string
 
+	// create_gitops_prs rule
+	ResolvedBinaries SliceFlags
+	ResolvedPushes   SliceFlags
+
 	// Dependencies
 	DependencyKinds []string
 	DependencyNames []string
@@ -91,6 +95,10 @@ func initConfig() *Config {
 	flag.StringVar(&cfg.PRTitle, "gitops_pr_title", "", "PR title")
 	flag.StringVar(&cfg.PRBody, "gitops_pr_body", "", "PR body message")
 	flag.StringVar(&cfg.DeploymentBranchSuffix, "deployment_branch_suffix", "", "Suffix for deployment branch names")
+
+	// create_gitops_prs rule sets these when used with `bazel run`
+	flag.Var(&cfg.ResolvedBinaries, "resolved_binary", "list of resolved gitops binaries to run. Can be specified multiple times. format is releasetrain:cmd/binary/to/run/command. Default is empty")
+	flag.Var(&cfg.ResolvedPushes, "resolved_push", "list of resolved push binaries to run. Can be specified multiple times. format is cmd/binary/to/run/command. Default is empty")
 
 	// Dependencies
 	var kinds, names, attrs SliceFlags
@@ -143,6 +151,27 @@ func executeBazelQuery(query string) *analysis.CqueryResult {
 	}
 
 	return result
+}
+
+func processResolvedImages(cfg *Config) {
+	resolvedPushChan := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(cfg.PushParallelism)
+
+	for i := 0; i < cfg.PushParallelism; i++ {
+		go func() {
+			defer wg.Done()
+			for target := range resolvedPushChan {
+				processTarget(target, cfg.BazelCmd)
+			}
+		}()
+	}
+
+	for _, r := range cfg.ResolvedPushes {
+		resolvedPushChan <- r
+	}
+	close(resolvedPushChan)
+	wg.Wait()
 }
 
 func processImages(targets []string, cfg *Config) {
@@ -231,17 +260,30 @@ func main() {
 		}
 	}
 
-	// Find release trains
-	query := fmt.Sprintf("attr(deployment_branch, \".+\", attr(release_branch_prefix, \"%s\", kind(gitops, %s)))",
-		cfg.ReleaseBranch, cfg.Targets)
-
-	result := executeBazelQuery(query)
-
 	trains := make(map[string][]string)
-	for _, t := range result.Results {
-		for _, attr := range t.Target.GetRule().GetAttribute() {
-			if attr.GetName() == "deployment_branch" {
-				trains[attr.GetStringValue()] = append(trains[attr.GetStringValue()], t.Target.Rule.GetName())
+	if len(cfg.ResolvedBinaries) > 0 {
+		// This condition is used when calling the script from create_gitops_pr rules
+		// When you call `bazel run <create_gitops_pr target>`, you can't call another bazel query within a bazel run command
+		// So we have to rely on resolved binaries that were passed in
+		for _, rb := range cfg.ResolvedBinaries {
+			releaseTrain, bin, found := strings.Cut(rb, ":")
+			if !found {
+				log.Fatalf("resolved_binaries: invalid resolved_binary format: %s", rb)
+			}
+			trains[releaseTrain] = append(trains[releaseTrain], bin)
+		}
+	} else {
+		// Find release trains
+		query := fmt.Sprintf("attr(deployment_branch, \".+\", attr(release_branch_prefix, \"%s\", kind(gitops, %s)))",
+			cfg.ReleaseBranch, cfg.Targets)
+
+		result := executeBazelQuery(query)
+
+		for _, t := range result.Results {
+			for _, attr := range t.Target.GetRule().GetAttribute() {
+				if attr.GetName() == "deployment_branch" {
+					trains[attr.GetStringValue()] = append(trains[attr.GetStringValue()], t.Target.Rule.GetName())
+				}
 			}
 		}
 	}
@@ -317,7 +359,11 @@ func main() {
 		return
 	}
 
-	processImages(updatedTargets, cfg)
+	if len(cfg.ResolvedPushes) > 0 {
+		processResolvedImages(cfg)
+	} else {
+		processImages(updatedTargets, cfg)
+	}
 
 	if !cfg.DryRun {
 		slug := os.Getenv("BUILDKITE_PIPELINE_SLUG")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`create_gitops_prs` rule is undocumented, but it's useful when running dozens of gitops targets at once. It runs `k8s_deploy` and image pushes in parallel. 

This PR adds back the `create_gitops_prs` rule that was originally taken out in a fork + add GitHub app specific flags.

## Motivation and Context

Sciences is interested in running the dry run per PR commit. RIght now we're running `bazel run` sequentially for all `gitops` targets which takes > 10 minutes. This change would help us run it in < 2 mins.

## How Has This Been Tested?

Tested with Sciences code

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
