### PR TITLE
Update image templating logic

### DIFF
--- a/push_oci/push_oci.bzl
+++ b/push_oci/push_oci.bzl
@@ -120,7 +120,11 @@ def push_oci(
 
     if not repository:
         label = native.package_relative_label(image)
-        repository = "{}/{}".format(label.package, label.name)
+        if label.package == "":
+            # When the  target is in root dir, package returns an empty string (e.g. images pulled by oci_pull)
+            repository = "external/{}".format(label.name)
+        else:
+            repository = "{}/{}".format(label.package, label.name)
     if registry:
         repository = "{}/{}".format(registry, repository)
     push_oci_rule(

--- a/resolver/pkg/resolver.go
+++ b/resolver/pkg/resolver.go
@@ -74,9 +74,9 @@ type imageTagTransformer struct {
 }
 
 /*
- findAndReplaceTag replaces the image tags inside one object
- It searches the object for container session
- then loops though all images inside containers session, finds matched ones and update the tag name
+findAndReplaceTag replaces the image tags inside one object
+It searches the object for container session
+then loops though all images inside containers session, finds matched ones and update the tag name
 */
 func (pt *imageTagTransformer) findAndReplaceTag(obj map[string]interface{}) error {
 	found := false
@@ -111,17 +111,76 @@ func (pt *imageTagTransformer) findAndReplaceTag(obj map[string]interface{}) err
 	return nil
 }
 
+func (pt *imageTagTransformer) resolveImageName(imagename string) (string, bool) {
+	// Try direct lookup first
+	if newname, ok := pt.images[imagename]; ok {
+		return newname, true
+	}
+
+	// If image starts with :, try looking up without the : prefix
+	if strings.HasPrefix(imagename, ":") {
+		trimmedName := strings.TrimPrefix(imagename, ":")
+		if newname, ok := pt.images[trimmedName]; ok {
+			return newname, true
+		}
+	}
+
+	// If image starts with @, try looking up without the @ prefix
+	if strings.HasPrefix(imagename, "@") {
+		trimmedName := strings.TrimPrefix(imagename, "@")
+		if newname, ok := pt.images[trimmedName]; ok {
+			return newname, true
+		}
+	}
+
+	return "", false
+}
+
+// In Sciences, some apps set an image URL as app env variables (e.g. trampoline)
+// resolver needs to be able to resolve bazel targets referenced in the env KV pair
+func (pt *imageTagTransformer) updateContainerEnv(container map[string]interface{}) {
+	env, found := container["env"].([]interface{})
+	if !found {
+		return
+	}
+	for _, kvInterface := range env {
+		kv, kvOk := kvInterface.(map[string]interface{})
+		if !kvOk {
+			return
+		}
+		envName, nameOk := kv["name"].(string)
+		if !nameOk {
+			return
+		}
+		// The pattern so far sets the env var name suffix as 'IMAGE_URL'
+		if strings.Contains(envName, "IMAGE_URL") {
+			envValue, valueOk := kv["value"].(string)
+			if !valueOk {
+				return
+			}
+			// Check if it's a valid Bazel target
+			if strings.HasPrefix(envValue, "//") {
+				kv["value"] = pt.images[envValue]
+			}
+			if strings.HasPrefix(envValue, ":") {
+				kv["value"] = pt.images[envValue[1:]]
+			}
+		}
+	}
+}
+
 func (pt *imageTagTransformer) updateContainers(obj map[string]interface{}, path string) error {
 	containers := obj[path].([]interface{})
 	for i := range containers {
 		container := containers[i].(map[string]interface{})
+		pt.updateContainerEnv(container)
 		image, found := container["image"]
 		if !found {
 			continue
 		}
 		imagename, imagenameOk := image.(string)
 		if imagenameOk {
-			if newname, ok := pt.images[imagename]; ok {
+			if newname, ok := pt.resolveImageName(imagename); ok {
 				container["image"] = newname
 				continue
 			}
@@ -135,6 +194,7 @@ func (pt *imageTagTransformer) updateContainers(obj map[string]interface{}, path
 
 func (pt *imageTagTransformer) updateContainer(obj map[string]interface{}, path string) error {
 	container := obj[path].(map[string]interface{})
+	pt.updateContainerEnv(container)
 	image, found := container["image"]
 	if found {
 		imagename, imagenameOk := image.(string)
@@ -142,7 +202,7 @@ func (pt *imageTagTransformer) updateContainer(obj map[string]interface{}, path 
 			if strings.HasPrefix(imagename, "//") {
 				return fmt.Errorf("unresolved image found: %s", imagename)
 			}
-			if newname, ok := pt.images[imagename]; ok {
+			if newname, ok := pt.resolveImageName(imagename); ok {
 				container["image"] = newname
 			}
 		}

--- a/resolver/pkg/resolver_test.go
+++ b/resolver/pkg/resolver_test.go
@@ -40,6 +40,14 @@ func TestNoError(t *testing.T) {
 		{"zk", map[string]string{
 			"zk-image": "dummy",
 		}},
+		{"container_env", map[string]string{
+			"nginx":   "docker.io/library/nginx:tag",
+			"envoy":   "docker.io/library/envoy:tag",
+			"//envoy": "docker.io/library/envoy:tag",
+		}},
+		{"external_image", map[string]string{
+			"etcd": "docker.io/library/etcd:tag",
+		}},
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/resolver/pkg/testdata/container_env.expected.yaml
+++ b/resolver/pkg/testdata/container_env.expected.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - env:
+        - name: ENVOY_IMAGE_URL
+          value: docker.io/library/envoy:tag
+        - name: BACKUP_ENVOY_IMAGE_URL
+          value: docker.io/library/envoy:tag
+        image: docker.io/library/nginx:tag
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/resolver/pkg/testdata/container_env.yaml
+++ b/resolver/pkg/testdata/container_env.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - env:
+            - name: ENVOY_IMAGE_URL
+              value: :envoy
+            - name: BACKUP_ENVOY_IMAGE_URL
+              value: //envoy
+          image: nginx
+          name: nginx
+          ports:
+            - containerPort: 80

--- a/resolver/pkg/testdata/external_image.expected.yaml
+++ b/resolver/pkg/testdata/external_image.expected.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: etcd
+  name: etcd-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      containers:
+      - image: docker.io/library/etcd:tag
+        name: etcd
+        ports:
+        - containerPort: 80

--- a/resolver/pkg/testdata/external_image.yaml
+++ b/resolver/pkg/testdata/external_image.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: etcd
+  name: etcd-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      containers:
+        - image: "@etcd"
+          name: etcd
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Specify repo package when using root-level images (e.g. from oci_pulls)
- Handle when `image` field in a yaml uses `:image` or `@image` labels
- Update image targets in container env vars for particular cases

## Motivation and Context

Current templating logic missed some `image` use cases in Sciences. 

## How Has This Been Tested?

Tested with Sciences code

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
