### PR TITLE
Add branch_name to create_gitops_prs rule

### DIFF
--- a/gitops/create_gitops_prs.tpl.sh
+++ b/gitops/create_gitops_prs.tpl.sh
@@ -4,5 +4,6 @@ set -e
 
 CURR_GIT_COMMIT=$(git rev-parse HEAD)
 GIT_COMMIT=${BUILDKITE_COMMIT:-$CURR_GIT_COMMIT}
+BRANCH_NAME="sciences-${GIT_COMMIT:0:7}"
 
-%{prer} --git_commit $GIT_COMMIT %{params}
+%{prer} --git_commit $GIT_COMMIT --branch_name $BRANCH_NAME %{params}

--- a/gitops/gitops.bzl
+++ b/gitops/gitops.bzl
@@ -8,7 +8,6 @@ def __create_gitops_prs_impl(ctx):
             src_by_train[gai.deployment_branch] = []
         src_by_train[gai.deployment_branch].append(src.files_to_run.executable)
 
-    # print("src_by_train:", src_by_train)
     trans_img_pushes = depset(transitive = [obj[GitopsArtifactsInfo].image_pushes for obj in ctx.attr.srcs if obj.files_to_run.executable]).to_list()
     params = ""
     for deployment_branch in src_by_train.keys():
@@ -19,6 +18,8 @@ def __create_gitops_prs_impl(ctx):
         params += "--resolved_push {} ".format(exe.files_to_run.executable.short_path)
     if ctx.attr.release_branch:
         params += "--release_branch {} ".format(ctx.attr.release_branch)
+    if ctx.attr.branch_name:
+        params += "--branch_name {} ".format(ctx.attr.branch_name)
     if ctx.attr.git_repo:
         params += "--git_repo {} ".format(ctx.attr.git_repo)
     if ctx.attr.gitops_path:
@@ -52,6 +53,7 @@ def __create_gitops_prs_impl(ctx):
     if ctx.attr.private_key:
         params += "--private_key {} ".format(ctx.attr.private_key)
 
+    # git_commit & branch_name params are set in _tpl since it's read from env variables
     ctx.actions.expand_template(
         template = ctx.file._tpl,
         substitutions = {
@@ -107,6 +109,9 @@ create_gitops_prs = rule(
         ),
         "release_branch": attr.string(
             doc = "release branch to create PRs in.",
+        ),
+        "branch_name": attr.string(
+            doc = "brach name to be used for the PR",
         ),
         "deploy_branch_prefix": attr.string(
             doc = "prefix for deployment branches",

--- a/gitops/gitops.bzl
+++ b/gitops/gitops.bzl
@@ -18,8 +18,6 @@ def __create_gitops_prs_impl(ctx):
         params += "--resolved_push {} ".format(exe.files_to_run.executable.short_path)
     if ctx.attr.release_branch:
         params += "--release_branch {} ".format(ctx.attr.release_branch)
-    if ctx.attr.branch_name:
-        params += "--branch_name {} ".format(ctx.attr.branch_name)
     if ctx.attr.git_repo:
         params += "--git_repo {} ".format(ctx.attr.git_repo)
     if ctx.attr.gitops_path:
@@ -109,9 +107,6 @@ create_gitops_prs = rule(
         ),
         "release_branch": attr.string(
             doc = "release branch to create PRs in.",
-        ),
-        "branch_name": attr.string(
-            doc = "brach name to be used for the PR",
         ),
         "deploy_branch_prefix": attr.string(
             doc = "prefix for deployment branches",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When we use `create_gitops_prs`, currently `branch_name` param isn't set. rules_gitops sets it to the default value which is `unknown`:
![CleanShot 2025-06-11 at 15 55 28@2x](https://github.com/user-attachments/assets/0f3858f1-9b3a-4ffb-8903-89fbcc011370)

This issue was undetected and it worked for some time, but we started to get these git related errors ([buildkite job](doc.new)):
![CleanShot 2025-06-11 at 15 58 10@2x](https://github.com/user-attachments/assets/3cf9e0a6-fcdb-4218-b6c3-35b22af317ac)

While the actual issue on GitHub side is unknown, I suspect it's due to us reusing the same branch. This PR adds a `branch_name` param to the `create_gitops_prs.go` as expected. 

## Motivation and Context

[SRVSRE-8556](https://etsy.atlassian.net/jira/software/projects/SRVSRE/boards/61?selectedIssue=SRVSRE-8556)

## How Has This Been Tested?
The feature branch was used in `git_override` in local copy of Sciences on my workstations. It was able to pass the branch name in dry-run mode:
![CleanShot 2025-06-11 at 16 01 12@2x](https://github.com/user-attachments/assets/bd81aa24-ee71-4f49-af28-3e87d846f66c)

[SRVSRE-8556]: https://etsy.atlassian.net/browse/SRVSRE-8556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ